### PR TITLE
Inhibit warning about adding storage wrapper too early

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -49,6 +49,7 @@ class Application extends App implements IBootstrap {
 	}
 
 	public function setupWrapper() {
+		$previousLog = \OC\Files\Filesystem::logWarningWhenAddingStorageWrapper(false);
 		\OC\Files\Filesystem::addStorageWrapper(
 			'sharepermissions',
 			function ($mountPoint, IStorage $storage) {
@@ -63,5 +64,6 @@ class Application extends App implements IBootstrap {
 			},
 			-15
 		);
+		\OC\Files\Filesystem::logWarningWhenAddingStorageWrapper($previousLog);
 	}
 }


### PR DESCRIPTION
The app maintainer likely knew what he was doing so doing it in this
place should be ok.

Fixes https://github.com/nextcloud/sharepermissions/issues/4